### PR TITLE
mission-direction-choice.lua - add sui box to allow player to select …

### DIFF
--- a/MMOCoreORB/bin/scripts/screenplays/screenplays.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/screenplays.lua
@@ -61,6 +61,7 @@ includeFile("utils/quest_spawner.lua")
 includeFile("tools/tools.lua")
 includeFile("tools/shuttle_dropoff.lua")
 includeFile("tools/firework_event.lua")
+includeFile("tools/mission_direction_choice.lua")
 
 includeFile("trainers/trainerData.lua")
 includeFile("trainers/skillTrainer.lua")

--- a/MMOCoreORB/bin/scripts/screenplays/tools/mission_direction_choice.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/tools/mission_direction_choice.lua
@@ -1,0 +1,94 @@
+-- Allows players to choose the direction they want to take destroy missions
+--
+--							N 90
+--							|
+--					NW 135  |	NE 45
+--						  \ | /
+--						   \|/
+--			W 180 ----------+---------- E 0 and 360
+--						   /|\
+--						  / | \
+--					SW 225	|  SE 315
+--							|
+--							S 270
+
+mission_direction_choice = ScreenPlay:new {
+	numberOfActs = 1,
+
+	directions = {
+		{dirDesc = "Reset mission direction", dirSelect = 0},
+		{dirDesc = "North", dirSelect = 90},
+		{dirDesc = "North East", dirSelect = 45},
+		{dirDesc = "East", dirSelect = 360}, 
+		{dirDesc = "South East", dirSelect = 315}, 
+		{dirDesc = "South", dirSelect = 270}, 
+		{dirDesc = "South West", dirSelect = 225}, 
+		{dirDesc = "West", dirSelect = 180}, 
+		{dirDesc = "North West", dirSelect = 135}, 
+	}
+}
+
+function mission_direction_choice:start()
+
+end
+
+function mission_direction_choice:openWindow(pPlayer)
+	if (pPlayer == nil) then
+		return
+	end
+
+	self:showLevels(pPlayer)
+end
+
+function mission_direction_choice:showLevels(pPlayer)
+
+	local cancelPressed = (eventIndex == 1)
+
+	if (cancelPressed) then
+		return
+	end
+
+	local sui = SuiListBox.new("mission_direction_choice", "dirSelection") -- calls dirSelection on SUI window event
+
+	sui.setTargetNetworkId(SceneObject(pPlayer):getObjectID())
+
+	sui.setTitle("Mission Direction Selection")
+
+	local promptText = "Select a direction which you would like to take missions.  After you have chosen, use the mission terminal to get a selection of missions (if any exist) in that direction.  \n\nIf no missions are offered to you, it is because terrain is unsuitable for missions in that direction from your current location and you will need to choose another direction.\n\nWhen you want to go back to the 'normal' selection of missions (any direction), just choose Reset mission direction."
+
+	sui.setPrompt(promptText)
+
+	for i = 1,  #self.directions, 1 do
+		sui.add(self.directions[i].dirDesc, "")
+	end
+
+	sui.sendTo(pPlayer)
+end
+
+function  mission_direction_choice:dirSelection(pPlayer, pSui, eventIndex, args)
+
+	local cancelPressed = (eventIndex == 1)
+
+	if (cancelPressed) then
+		return 
+	end
+
+	if (args == "-1") then
+		CreatureObject(pPlayer):sendSystemMessage("No direction was selected...")
+		return
+	end
+
+	local selectedIndex = tonumber(args)+1
+
+	local selectedDir = tonumber(self.directions[selectedIndex].dirSelect)
+	local selectedDirDesc = self.directions[selectedIndex].dirDesc
+
+	writeScreenPlayData(pPlayer, "mission_direction_choice", "directionChoice", selectedDir) 
+
+	if (selectedDir == 0) then
+		CreatureObject(pPlayer):sendSystemMessage("Mission direction has been reset to normal.")
+	else	
+		CreatureObject(pPlayer):sendSystemMessage("You have selected missions to the " .. selectedDirDesc .. ". This choice will remain active until you change or reset it.")
+	end
+
+end

--- a/MMOCoreORB/src/server/zone/managers/mission/MissionManagerImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/managers/mission/MissionManagerImplementation.cpp
@@ -788,6 +788,11 @@ void MissionManagerImplementation::randomizeGenericDestroyMission(CreatureObject
 		diffDisplay += playerLevel;
 	}
 
+	PlayerObject* targetGhost = player->getPlayerObject();
+
+	String dir = targetGhost->getScreenPlayData("mission_direction_choice", "directionChoice");
+	float dirChoice = Float::valueOf(dir);
+
 	String building = lairTemplateObject->getMissionBuilding(difficulty);
 
 	if (building.isEmpty()) {
@@ -814,7 +819,27 @@ void MissionManagerImplementation::randomizeGenericDestroyMission(CreatureObject
 
 		int distance = destroyMissionBaseDistance + destroyMissionDifficultyDistanceFactor * difficultyLevel;
 		distance += System::random(destroyMissionRandomDistance) + System::random(destroyMissionDifficultyRandomDistance * difficultyLevel);
-		startPos = player->getWorldCoordinate((float)distance, (float)System::random(360), false);
+
+		float direction = (float)System::random(360);
+
+		//Player direction choice +/- 10 degrees deviation
+		if (dirChoice > 0) {
+			int deviation = System::random(10);
+			int isMinus = System::random(100);
+
+			if (isMinus > 40)
+				deviation *= -1;
+
+			direction = dirChoice + deviation;
+
+			//Fix value more than max (360)
+			if (direction > 360) 
+				direction -= 360
+		}
+
+		// startPos = player->getWorldCoordinate((float)distance, (float)System::random(360), false);
+		startPos = player->getWorldCoordinate((float)distance, direction, false);
+
 
 		if (zone->isWithinBoundaries(startPos)) {
 			float height = zone->getHeight(startPos.getX(), startPos.getY());

--- a/MMOCoreORB/src/server/zone/objects/tangible/terminal/mission/MissionTerminalImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/tangible/terminal/mission/MissionTerminalImplementation.cpp
@@ -12,6 +12,8 @@
 #include "server/zone/managers/city/CityManager.h"
 #include "server/zone/managers/city/CityRemoveAmenityTask.h"
 #include "server/zone/objects/player/sessions/SlicingSession.h"
+#include "server/zone/managers/director/DirectorManager.h"
+#include "server/zone/objects/player/PlayerObject.h"
 
 void MissionTerminalImplementation::fillObjectMenuResponse(ObjectMenuResponse* menuResponse, CreatureObject* player) {
 	TerminalImplementation::fillObjectMenuResponse(menuResponse, player);
@@ -27,6 +29,10 @@ void MissionTerminalImplementation::fillObjectMenuResponse(ObjectMenuResponse* m
 		menuResponse->addRadialMenuItemToRadialID(73, 75, 3, "@city/city:east"); // East
 		menuResponse->addRadialMenuItemToRadialID(73, 76, 3, "@city/city:south"); // South
 		menuResponse->addRadialMenuItemToRadialID(73, 77, 3, "@city/city:west"); // West
+	}
+
+	if (terminalType == "general") {
+		menuResponse->addRadialMenuItem(113, 3, "Choose Mission Direction");
 	}
 }
 
@@ -77,6 +83,13 @@ int MissionTerminalImplementation::handleObjectMenuSelect(CreatureObject* player
 		CityManager* cityManager = getZoneServer()->getCityManager();
 		cityManager->alignAmenity(city, player, _this.getReferenceUnsafeStaticCast(), selectedID - 74);
 
+		return 0;
+	} else if (selectedID == 113) {
+		Lua* lua = DirectorManager::instance()->getLuaInstance();
+		Reference<LuaFunction*> mission_direction_choice = lua->createFunction("mission_direction_choice", "openWindow", 0);
+		*mission_direction_choice << player;
+
+		mission_direction_choice->callFunction();
 		return 0;
 	}
 


### PR DESCRIPTION
…mission direction

screenplays.lua - add mission_direction_choice to screenplays to make sure its loaded MissionTerminalImplementation - add the ability to select the choose mission direction from radial menu MissionManagerImplementation - get the players choice of direction and have this used when selecting a mission