### PR TITLE
mission_level_choice.lua - add sui box to allow player to select miss…

### DIFF
--- a/MMOCoreORB/bin/scripts/screenplays/screenplays.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/screenplays.lua
@@ -61,6 +61,7 @@ includeFile("utils/quest_spawner.lua")
 includeFile("tools/tools.lua")
 includeFile("tools/shuttle_dropoff.lua")
 includeFile("tools/firework_event.lua")
+includeFile("tools/mission_level_choice.lua")
 
 includeFile("trainers/trainerData.lua")
 includeFile("trainers/skillTrainer.lua")

--- a/MMOCoreORB/bin/scripts/screenplays/tools/mission_level_choice.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/tools/mission_level_choice.lua
@@ -1,0 +1,84 @@
+--Allows players to select a mission level range, regardless of their own combat level
+
+mission_level_choice = ScreenPlay:new {
+    numberOfActs = 1,
+
+    levels = {
+        {levelRange = "Reset Level Range", levelSelect = 0},
+        {levelRange = "Easiest", levelSelect = 1},
+        {levelRange = "Mid 1", levelSelect = 2},
+        {levelRange = "Mid 2", levelSelect = 12},
+        {levelRange = "Mid 3", levelSelect = 25},
+        {levelRange = "High 1", levelSelect = 35},
+        {levelRange = "High 2", levelSelect = 45},
+        {levelRange = "High 3", levelSelect = 60},
+        {levelRange = "Hard", levelSelect = 135},
+        {levelRange = "Hardest", levelSelect = 200},
+    }
+}
+
+function mission_level_choice:start()
+
+end
+
+function mission_level_choice:openWindow(pPlayer)
+    if (pPlayer == nil) then
+        return
+    end
+
+    self:showLevels(pPlayer)
+
+end
+
+function mission_level_choice:showLevels(pPlayer)
+    local cancelPressed = (eventIndex == 1)
+
+    if (cancelPressed) then
+        return
+    end
+
+    local sui = SuiListBox.new("mission_level_choice", "levelSelection") -- calls level selection on a SUI window event
+
+    sui.setTargetNetworkId(SceneObject(pPlayer):getObjectID())
+
+    sui.setTitle("Mission level selection")
+
+    local text = "Use this menu to select a mission level range to aim for. After you have chosen a range, use the mission terminal to get a selection of missions.\n\nIf no missions are shown, it is because no missions in that level range exist for this planet. You will need to choose another range.\n\nWhen you want to back to 'normal' offering of missions for your skill level, just choose Reset Level Range."
+
+    sui.setPrompt(text)
+
+    for i = 1, #self.levels, 1 do
+        sui.add(Self.levels[i].levelRange, "")
+    end
+
+    sui.sendTo(pPlayer)
+end
+
+function  mission_level_choice:levelSelection(pPlayer, pSui, eventIndex, args)
+
+	local cancelPressed = (eventIndex == 1)
+
+	if (cancelPressed) then
+		return 
+	end
+
+	if (args == "-1") then
+		CreatureObject(pPlayer):sendSystemMessage("No level selected...")
+		return
+	end
+
+	local selectedLevelIndex = tonumber(args)+1
+
+	local selectedLevel = self.levels[selectedLevelIndex].levelSelect
+	local selectedRange = self.levels[selectedLevelIndex].levelRange
+
+	writeScreenPlayData(pPlayer, "mission_level_choice", "levelChoice", selectedLevel) 
+
+	if (tonumber(selectedLevel) == 0) then
+		CreatureObject(pPlayer):sendSystemMessage("You have selected: " .. selectedRange .. ".  You may now choose missions suited to your own skill/group level.")
+	else	
+		CreatureObject(pPlayer):sendSystemMessage("You have selected: " .. selectedRange .. ".  These missions would be considered suitable for a player or group of level " .. selectedLevel .. ".")
+
+	end
+
+end

--- a/MMOCoreORB/src/server/zone/managers/mission/MissionManagerImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/managers/mission/MissionManagerImplementation.cpp
@@ -776,7 +776,16 @@ void MissionManagerImplementation::randomizeGenericDestroyMission(CreatureObject
 
 	int diffDisplay = difficultyLevel < 5 ? 4 : difficultyLevel;
 
-	if (player->isGrouped()) {
+	PlayerObject* targetGhost = player->getPlayerObject();
+
+	String level = targetGhost->getScreenPlayData("mission_level_choice", "levelChoice");
+
+	int levelChoice = Integer::valueOf(level);
+
+	if (levelChoice > 0) 
+		diffDisplay += levelChoice;
+
+	else if (player->isGrouped()) {
 		bool includeFactionPets = faction != Factions::FACTIONNEUTRAL || ConfigManager::instance()->includeFactionPetsForMissionDifficulty();
 		Reference<GroupObject*> group = player->getGroup();
 
@@ -1816,7 +1825,16 @@ LairSpawn* MissionManagerImplementation::getRandomLairSpawn(CreatureObject* play
 	int counter = availableLairList->size();
 	int playerLevel = server->getPlayerManager()->calculatePlayerLevel(player);
 
-	if (player->isGrouped()) {
+	PlayerObject* targetGhost = player->getPlayerObject();
+
+	String level = targetGhost->getScreenPlayData("mission_level_choice", "levelChoice");
+
+	int levelChoice = Integer::valueOf(level);
+
+	if (levelChoice > 0)
+		playerLevel = levelChoice;
+
+	else if (player->isGrouped()) {
 		bool includeFactionPets = faction != Factions::FACTIONNEUTRAL || ConfigManager::instance()->includeFactionPetsForMissionDifficulty();
 		Reference<GroupObject*> group = player->getGroup();
 

--- a/MMOCoreORB/src/server/zone/objects/tangible/terminal/mission/MissionTerminalImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/tangible/terminal/mission/MissionTerminalImplementation.cpp
@@ -12,6 +12,8 @@
 #include "server/zone/managers/city/CityManager.h"
 #include "server/zone/managers/city/CityRemoveAmenityTask.h"
 #include "server/zone/objects/player/sessions/SlicingSession.h"
+#include "server/zone/manager/director/DirectorManager.h"
+#include "server/zone/objects/player/PlayerObject.h"
 
 void MissionTerminalImplementation::fillObjectMenuResponse(ObjectMenuResponse* menuResponse, CreatureObject* player) {
 	TerminalImplementation::fillObjectMenuResponse(menuResponse, player);
@@ -28,6 +30,9 @@ void MissionTerminalImplementation::fillObjectMenuResponse(ObjectMenuResponse* m
 		menuResponse->addRadialMenuItemToRadialID(73, 76, 3, "@city/city:south"); // South
 		menuResponse->addRadialMenuItemToRadialID(73, 77, 3, "@city/city:west"); // West
 	}
+
+	if (terminalType == "general")
+		menuResponse->addRadialMenuItem(112, 3, "Choose Mission Level");
 }
 
 int MissionTerminalImplementation::handleObjectMenuSelect(CreatureObject* player, byte selectedID) {
@@ -78,7 +83,18 @@ int MissionTerminalImplementation::handleObjectMenuSelect(CreatureObject* player
 		cityManager->alignAmenity(city, player, _this.getReferenceUnsafeStaticCast(), selectedID - 74);
 
 		return 0;
+	} else if (selectedID == 112) {
+
+		Lua* lua = DirectorManager::instance()->getLuaInstance();
+
+		Reference<LuaFunction*> mission_level_choice = lua->createFunction("mission_level_choice", "openWindow", 0);
+		*mission_level_choice << player;
+
+		mission_level_choice->callFunction();
+		return 0;
 	}
+
+
 
 	return TangibleObjectImplementation::handleObjectMenuSelect(player, selectedID);
 }


### PR DESCRIPTION
…ion level

screenplays.lua - add mission_level_choice.lua to screeplays file to make sure its loaded MissionTerminalImplementation.cpp - add the ability to select the choose mission level from mission terminal radial menu MissionManagerImplementation.cpp - get the players choice of mission level and have this used in calculating the level of mission to display